### PR TITLE
use back-ticks for CHAIN_START_FULL_DEPOSIT_THRESHOLD

### DIFF
--- a/roadmap/timeline/serenity-phases.md
+++ b/roadmap/timeline/serenity-phases.md
@@ -24,7 +24,7 @@ Once Phase 0 is complete, there will be two active Ethereum chains. For the sake
 
 **Important Considerations**
 
-* There will be a minimum amount of ETH stake needed in order to first bootstrap the beacon chain. This is defined as "CHAIN\_START\_FULL\_DEPOSIT\_THRESHOLD" in the spec. Currently, this is set to 16384 validators needed. That would mean 524,288 ETH in total stake is needed. This would pay ~11% interest to stakers.
+* There will be a minimum amount of ETH stake needed in order to first bootstrap the beacon chain. This is defined as `CHAIN_START_FULL_DEPOSIT_THRESHOLD` in the spec. Currently, this is set to 16384 validators needed. That would mean 524,288 ETH in total stake is needed. This would pay ~11% interest to stakers.
 * ETH rewards earned by validators won’t be transferable until Phase 2 of the Serenity roll-out as that is when state execution is implemented.
 * During Phase 0, all Ethereum transactions and smart contract computations will still occur on the Eth 1.0 chain.
 * Once the beacon chain is advancing, Eth 1.0 clients can refer to the beacon chain for finalized beacon blocks and use that as the finality checkpoint for the Eth 1.0 PoW chain.


### PR DESCRIPTION
In markdown docs, back-ticks are commonly use for code snippets, var names, constants, etc