### PR TITLE
Update to Defaults for Full Nodes

### DIFF
--- a/using-ethereum/running-a-node/README.md
+++ b/using-ethereum/running-a-node/README.md
@@ -21,9 +21,7 @@ Light node:
 
 Full node:
 
-* **geth**: --syncmode "fast"
-
-The parity default settings are the best for full nodes.
+The default settings for Geth and Parity are the best for full nodes.
 
 ## Table of node settings
 


### PR DESCRIPTION
Geth's [default](https://github.com/ethereum/go-ethereum/blob/master/eth/config.go#L36-L38) has been fast for a long time now