### PR TITLE
Add EthereumJ / Harmony

### DIFF
--- a/using-ethereum/running-a-node/ethereumj.md
+++ b/using-ethereum/running-a-node/ethereumj.md
@@ -1,0 +1,14 @@
+# EthereumJ (Harmony)
+
+## Summary
+
+EthereumJ is a pure-Java implementation of the Ethereum protocol. Harmony is the front end client software and runs on top of EthereumJ. It is capable of fully syncing both ropsten and mainnet and is compatible with the Constantinople hardfork.
+
+## Resources
+
+### EthereumJ
+* [Github](https://github.com/ethereum/ethereumj) 
+* [Docs](http://ethdocs.org/en/latest/ethereum-clients/ethereumj/)
+
+### Harmony
+* [Github](https://github.com/ether-camp/ethereum-harmony) 


### PR DESCRIPTION
Should probably eventually add more details but I have personally ran Ethereum-Harmony node to full sync on both ropsten and mainnet. I think it should be added given that Trinity is also listed here.