### PR TITLE
Clarifying ownership of the Stable Fund

### DIFF
--- a/other/funds/README.md
+++ b/other/funds/README.md
@@ -6,7 +6,7 @@ List of all the Ethereum ventures / startup funds / Incubators / Grants / prizes
 * [Status Incubate](status-incubate.md) by Status.im
 * [Aragon Nest](aragon-nest.md) by aragon
 * [0x Ecosystem Acceleration Program](0xeap.md) by 0xProject
-* [Stable.fund](stable-fund.md) by L4 and MakerDAO
+* [The Stable Fund](stable-fund.md) by MakerDAO
 * [ConsenSys Ventures](consensys-vc.md) by ConsenSys
 * [ConsenSys labs](consensys-labs.md) by ConsenSys
 * [Gnosis X](gnosisx.md) by Gnosis


### PR DESCRIPTION
The Stable Fund has been moved in-house and is now administered by MakerDAO. I'm Rich Brown, Head of Community Development at MakerDAO and I'm currently responsible for the program. I can be reached at rich@makerdao.com or @richatmakerdao on Twitter if anyone would like to confirm. 