### PR TITLE
Specify `CHAIN_START_FULL_DEPOSIT_THRESHOLD` location

### DIFF
--- a/ethereum-roadmap/serenity-phases/README.md
+++ b/ethereum-roadmap/serenity-phases/README.md
@@ -34,7 +34,7 @@ Once Phase 0 is complete, there will be two active Ethereum chains. For the sake
 
 **Important Considerations**
 
-* There will be a minimum amount of ETH stake needed in order to first bootstrap the beacon chain. This is defined as `CHAIN_START_FULL_DEPOSIT_THRESHOLD` in the spec. Currently, this is set to 16384 validators needed. That would mean 524,288 ETH in total stake is needed. This would pay ~11% interest to stakers.
+* There will be a minimum amount of ETH stake needed in order to first bootstrap the beacon chain. This is defined as `CHAIN_START_FULL_DEPOSIT_THRESHOLD` in the [deposit contract that will live on the Eth 1.0 chain](https://github.com/ethereum/deposit_contract/blob/master/deposit_contract/contracts/validator_registration.v.py#L69). Currently, this is set to 16384 validators needed. That would mean 524,288 ETH in total stake is needed. This would pay ~11% interest to stakers.
 * ETH rewards earned by validators won’t be transferable until Phase 2 of the Serenity roll-out as that is when state execution is implemented.
 * During Phase 0, all user transactions and smart contract computations will still occur on the Eth 1.0 chain.
 


### PR DESCRIPTION
The `CHAIN_START_FULL_DEPOSIT_THRESHOLD` is not part of the ETH 2.0 spec, but part of the contract on the ETH 1.0 chain that the beacon chain listens too. I linked the contract from the Ethereum repo in the description.