### PR TITLE
Update how-to-buy-ether.md with Bitwage

### DIFF
--- a/docs/using-ethereum/how-to-buy-ether.md
+++ b/docs/using-ethereum/how-to-buy-ether.md
@@ -7,6 +7,11 @@ Binance is headquartered in Malta and constantly has some of the highest trading
 
 [Buy ETH on Binance](https://www.binance.com/?ref=10900939)
 
+## Bitwage
+Bitwage is headquartered in San Francisco and is the oldest and highest volume cryptocurrency payroll service. Users can get any percentage of their salary split between ETH and fiat, with or without their employer signing up.
+
+[Get Paid in ETH on Bitwage](https://www.bitwage.com)
+
 ## Coinbase
 Coinbase is based in San Fransisco and is one of the most reputable and well known exchanges in the world. Users can buy ETH with fiat or cryptocurrencies.
 


### PR DESCRIPTION
Adding Bitwage ETH payroll functionality to how-to-buy-ether.md page, as Bitwage payroll takes fiat currency from employers or clients and allows workers to receive ETH. Bitwage allows anyone to receive any portion of their wage in ETH from any employer.  https://www.coindesk.com/employers-can-now-pay-salaries-in-ether-via-crypto-startup-bitwage.