### PR TITLE
Update Trinity url

### DIFF
--- a/docs/ethereum-roadmap/ethereum-2.0/eth2.0-teams/trinity.md
+++ b/docs/ethereum-roadmap/ethereum-2.0/eth2.0-teams/trinity.md
@@ -15,5 +15,5 @@ The team are building Trinity - an Ethereum 1.0 and 2.0 client written in the pr
 ## Resources:
 
 * [Website](https://trinity.ethereum.org/)
-* [Github](https://github.com/ethereum/py-evm)
+* [Github](https://github.com/ethereum/trinity)
 


### PR DESCRIPTION
The Eth2.0 codebase is actually in the https://github.com/ethereum/trinity repo