### PR TITLE
Fix description for Chainstack, add to Enterprise

### DIFF
--- a/docs/built-on-ethereum/enterprise/chainstack.md
+++ b/docs/built-on-ethereum/enterprise/chainstack.md
@@ -10,7 +10,12 @@ Chainstack is a managed blockchain services provider that makes it
 simple to launch and scale decentralized networks and applications—complete with an intuitive user interface,
 seamless orchestration, and predictable pricing.
 
-Chainstack offers free shared Ethereum nodes.
+Chainstack offers enterprise-grade tools and services that empower developers,
+solution providers, and consortia to safely experiment and run in production.  
+
+By building on Chainstack, you reduce the time, cost, and risk involved with leveraging
+decentralized technologies. With a secure API, membership management, and flexible deployment options,
+you can immediately accelerate and future-proof your development of transformative solutions.
 
 ## Important links
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,6 +250,7 @@ nav:
     - 'Ethereum Enterprise': 'built-on-ethereum/enterprise/enterprise.md'
     - 'AXA': 'built-on-ethereum/enterprise/axa.md'
     - 'Axoni': 'built-on-ethereum/enterprise/axoni.md'
+    - 'Chainstack': 'built-on-ethereum/enterprise/chainstack.md'
     - 'Cloudflare': 'built-on-ethereum/enterprise/cloudflare.md'
     - 'Deloitte': 'built-on-ethereum/enterprise/deloitte.md'
     - 'DTCC': 'built-on-ethereum/enterprise/dtcc.md'


### PR DESCRIPTION
Fixed the description for Chainstack under infrastructure as it turned out
to not be rendering properly.

As Chainstack supports enterprise networks too, added to the Enterprise section