### PR TITLE
settle is gone 1/23

### DIFF
--- a/docs/ethereum-basics/resources.md
+++ b/docs/ethereum-basics/resources.md
@@ -130,7 +130,7 @@ description: A list of essential Ethereum resources.
 
 * [Loanscan - Ethereum Loan Explorer](https://loanscan.io/)
 * [State of the dApps](https://www.stateofthedapps.com/)
-* [Settle - Decentralized Finance OS](https://settle.finance/)
+* [DeFi Pulse - The Decentralized Finance Leaderboard](https://defipulse.com/)
 
 #### Ethereum Data Explorers
 


### PR DESCRIPTION
Replace link of Settle with DeFi Pulse since [Settle is gone 1/23 2020.](https://settle.finance/blog/goodbye-settle/) 