### PR TITLE
I added a newsletter in the newsletter section

### DIFF
--- a/site/ethereum-basics/resources/index.html
+++ b/site/ethereum-basics/resources/index.html
@@ -4090,6 +4090,7 @@
 <li><a href="https://www.tonysheng.com/">Tony Sheng</a></li>
 <li><a href="https://8xprotocol.com/protocol-weekly">Protocol Weekly</a></li>
 <li><a href="https://globalcoinresearch.com/">Global Coin Research</a></li>
+<li><a href="https://yieldfarmer.substack.com/">DeFi Pulse Farmer</a></li>
 </ul>
 <h3 id="social-media">Social Media</h3>
 <ul>
@@ -4336,7 +4337,7 @@
                 <span class="md-footer-nav__direction">
                   Previous
                 </span>
-                Tooling
+                Toolingf
               </span>
             </div>
           </a>


### PR DESCRIPTION
I added the DeFi Pulse Farmer newsletter (https://yieldfarmer.substack.com) in the newsletter section. But it seems that the Newsletter section on Github is not reflecting the same newsletters shown at https://docs.ethhub.io/ethereum-basics/resources/#newsletters.