### PR TITLE
Add eth2 explorer maintained by Redot

### DIFF
--- a/docs/ethereum-basics/resources.md
+++ b/docs/ethereum-basics/resources.md
@@ -135,6 +135,7 @@ description: A list of essential Ethereum resources.
 
 * [Etherscan](https://beacon.etherscan.io/)
 * [Etherchain](https://beaconcha.in/)
+* [Ethscan](https://ethscan.org/)
 
 #### Wallets
 


### PR DESCRIPTION
ethscan.org is an open-source eth2 explorer with a free public API maintained by redot.com