### PR TITLE
Update is-ethereum-over-1tb-in-size.md

### DIFF
--- a/docs/questions-about-ethereum/is-ethereum-over-1tb-in-size.md
+++ b/docs/questions-about-ethereum/is-ethereum-over-1tb-in-size.md
@@ -8,7 +8,7 @@ description: No, the Ethereum blockchain size has not exceeded 1TB in size.
 
 ## Answer
 
-No. Please check [here](https://etherscan.io/chartsync/chaindefault) for the latest size.
+Yes. Please check [here](https://etherscan.io/chartsync/chaindefault) for the latest size.
 
 ## Explanation
 


### PR DESCRIPTION
As of 2021-11-25, the size for GETH exceeds 1Tb