### PR TITLE
GETH Default is now over 1 TB

### DIFF
--- a/docs/questions-about-ethereum/is-ethereum-over-1tb-in-size.md
+++ b/docs/questions-about-ethereum/is-ethereum-over-1tb-in-size.md
@@ -1,14 +1,14 @@
 ---
 title: Is Ethereum over 1TB in size? - EthHub
 
-description: No, the Ethereum blockchain size has not exceeded 1TB in size.
+description: Yes, the Ethereum blockchain size has not exceeded 1TB in size.
 ---
 
 # Is Ethereum over 1TB in size?
 
 ## Answer
 
-No. Please check [here](https://etherscan.io/chartsync/chaindefault) for the latest size.
+Yes. Please check [here](https://etherscan.io/chartsync/chaindefault) for the latest size.
 
 ## Explanation
 


### PR DESCRIPTION
Time have changed and the given link (`https://etherscan.io/chartsync/chaindefault`) shows that the GETH Default config is now approximately 1,1 TB in size. 

