### PR TITLE
Update Besu page

### DIFF
--- a/docs/using-ethereum/ethereum-clients/besu.md
+++ b/docs/using-ethereum/ethereum-clients/besu.md
@@ -8,7 +8,11 @@ description: Besu is an open-source Ethereum client developed under the Apache 2
 
 ## Summary
 
-Hyperledger Besu is an open-source Ethereum client developed under the Apache 2.0 license and written in Java. It runs on the Ethereum public network, private networks, and test networks such as Rinkeby, Ropsten, and Görli. Besu implements Proof of Work (Ethash) and Proof of Authority (IBFT 2.0 and Clique) consensus mechanisms.
+Hyperledger Besu is an open-source Ethereum client developed under the Apache 2.0 license and written in Java.
+It runs on Ethereum Mainnet, private networks, and test networks such as Rinkeby, Ropsten, Goerli, and the Merge testnet.
+Besu serves as an execution client on Ethereum Mainnet and the Merge testnet.
+
+Besu implements Proof of Authority (QBFT, IBFT 2.0, and Clique) and Proof of Work (Ethash) consensus mechanisms.
 
 You can use Besu to develop enterprise applications requiring secure, high-performance transaction processing in a private network.
 


### PR DESCRIPTION
Update [Besu page](https://docs.ethhub.io/using-ethereum/ethereum-clients/besu/) to emphasize QBFT consensus and add post-Merge usage.

Fixes https://github.com/ConsenSys/protocol-misc/issues/585