### PR TITLE
Updated Ethereum testnets

### DIFF
--- a/docs/using-ethereum/test-networks.md
+++ b/docs/using-ethereum/test-networks.md
@@ -6,50 +6,15 @@ description: A list of all test networks currently live for Ethereum.
 
 # Test Networks
 
-## Ropsten
-
-### Summary
-
-The Ropsten test network is a Proof-of-Work testnet for Ethereum. To acquire ETH on Ropsten, one can mine on the network.
-
-### Resources
-
-* [Block Explorer](https://ropsten.etherscan.io/)
-
-## Kovan
-
-### Summary
-
-The Kovan test network is a Proof-of-Authority testnet for Ethereum, originally started by the Parity team. To acquire ETH on Kovan, one can request it from a faucet.
-
-### Resources
-
-* [Website](https://kovan-testnet.github.io/website/)  
-* [Block Explorer](https://kovan.etherscan.io/)  
-* [Faucet](https://faucet.kovan.network/)
-
-## Rinkeby
-
-### Summary
-
-The Rinkeby test network is a Proof-of-Authority testnet for Ethereum, originally started by the Geth team. To acquire ETH on Rinkeby, one can request it from a faucet.
-
-### Resources
-
-* [Website](https://www.rinkeby.io/#stats)
-* [Block Explorer](https://rinkeby.etherscan.io/)
-* [Faucet](https://faucet.rinkeby.io/)
-
 ## Görli
 
 ### Summary
 
-The Görli test network is a Proof-of-Authority testnet for Ethereum, originally proposed by Chainsafe and Afri Schoedon. To acquire ETH on Görli, one can use the one-way throttled bridge from any of the other three test networks.
+The Görli (also spelled "Goerli") test network is the primary testnet for Ethereum. To acquire testETH on Görli, anyone can get it from a faucet (see below). Since the Ethereum merge (fall 2022), all other testnets including Rinkeby, Ropsten, and Kovan, have been deprecated. This means that Goerli is the only testnet that developers should use. 
 
 ### Resources
 
-* [Website](https://goerli.net/)
+* [Faucet](https://goerlifaucet.com)
 * [Block Explorer](https://goerli.etherscan.io/)
 * [GitHub](https://github.com/goerli/testnet)
-* [Testnet proposal](https://dev.to/5chdn/the-grli-testnet-proposal---a-call-for-participation-58pf)
-* [Ethstats for Görli](https://stats.goerli.net/)
+ 


### PR DESCRIPTION
Given the recent Ethereum merge, Goerli is now the only Ethereum-supported testnet. Therefore, I removed the other deprecated testnets and added Alchemy's free Goerli faucet, one of the more popular faucets amongst developers.