### PR TITLE
Added "dapp tooling" and "developer docs" section

### DIFF
--- a/docs/ethereum-basics/resources.md
+++ b/docs/ethereum-basics/resources.md
@@ -122,6 +122,22 @@ description: A list of essential Ethereum resources.
 
 ### Ethereum Tools
 
+#### Dapp Tooling
+
+- [Alchemy](https://www.alchemy.com/)
+- [ethers.js](https://docs.ethers.io/v5/)
+- [Hardhat](https://hardhat.org/tutorial/deploying-to-a-live-network)
+- [Solidity](https://soliditylang.org/)
+- [Truffle](https://trufflesuite.com/guides/web3-development-stack/)
+
+#### Developer Docs & Tutorials
+
+- [Alchemy University](https://university.alchemy.com/#starter_code)
+- [Chainlink](https://blog.chain.link/learn-blockchain-full-stack-web3-javascript-smart-contract-development/)
+- [Ethereum StackExchange](https://ethereum.stackexchange.com/)
+- [Nader Dabit](https://naderdabit.notion.site/Nader-s-web3-Resources-for-Developers)
+- [Web3 University](https://www.web3.university/)
+
 #### Block Explorers
 
 * [Etherscan](https://etherscan.io/)


### PR DESCRIPTION
The technical section was missing (a) the set of tools to start actually reading and writing to the blockchain and (b) general web3 developer tutorials to learn how to read and write to the blockchain. 

I added the same list as exists on a similar Ethereum page (https://ethereum.org/en/community/support/). 
 
For (a), I added everything from this Ethereum page's "Tooling" section except for web3.js as ethers.js is much more broadly used. 

For (b) I added the following popular "how to learn web3 dev" resources and courses (all free) - Alchemy University, Chainlink (specifically Patrick Collins' famous 32 hour comprehensive course / video), and Nader Dabit as well as everything the Ethereum page had. In full transparency, I work for Alchemy and am submitting these because these resources consistently receive the most positive feedback from both the crypto community and our developers :) Please let me know of any questions.

Love what you guys do at ethhub, thanks!

Shelley